### PR TITLE
Add GitHub JSON source link to entity details pages

### DIFF
--- a/src/components/entity_details/GitHubSourceLink.tsx
+++ b/src/components/entity_details/GitHubSourceLink.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { getEntityGitHubUrl } from '../../utils/github';
+
+interface GitHubSourceLinkProps {
+  entityId: string;
+}
+
+const GitHubSourceLink: React.FC<GitHubSourceLinkProps> = ({ entityId }) => {
+  return (
+    <a 
+      href={getEntityGitHubUrl(entityId)} 
+      target="_blank" 
+      rel="noopener noreferrer"
+      style={{ 
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '6px',
+        padding: '8px 16px',
+        backgroundColor: '#24292e',
+        color: '#ffffff',
+        textDecoration: 'none',
+        borderRadius: '6px',
+        fontSize: '0.9em',
+        fontWeight: '500',
+        transition: 'background-color 0.2s ease',
+        border: 'none',
+        cursor: 'pointer'
+      }}
+      onMouseEnter={(e) => e.currentTarget.style.backgroundColor = '#1a1e22'}
+      onMouseLeave={(e) => e.currentTarget.style.backgroundColor = '#24292e'}
+    >
+      <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+        <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
+      </svg>
+      View JSON on GitHub
+      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
+        <polyline points="15 3 21 3 21 9"></polyline>
+        <line x1="10" y1="14" x2="21" y2="3"></line>
+      </svg>
+    </a>
+  );
+};
+
+export default GitHubSourceLink;

--- a/src/components/entity_details/InternationalOrgDetails.tsx
+++ b/src/components/entity_details/InternationalOrgDetails.tsx
@@ -9,8 +9,8 @@ import SectionHeader from './SectionHeader';
 import AttributesDisplay from './AttributesDisplay';
 import TagsDisplay from './TagsDisplay';
 import CollapsibleSection from './CollapsibleSection';
+import GitHubSourceLink from './GitHubSourceLink';
 import { formattedDate } from '../../utils/date';
-import { getEntityGitHubUrl } from '../../utils/github';
 
 interface InternationalOrgDetailsProps {
   entity: Organization;
@@ -130,38 +130,7 @@ const InternationalOrgDetails: React.FC<InternationalOrgDetailsProps> = ({ entit
             <DetailField label="Last Modified" labelNe="अन्तिम परिमार्जन">{formattedDate(new Date(entity.version_summary.created_at))}</DetailField>
             <DetailField label="Created At" labelNe="सिर्जना मिति">{formattedDate(new Date(entity.created_at))}</DetailField>
             <DetailField label="Source Data" labelNe="स्रोत डाटा">
-              <a 
-                href={getEntityGitHubUrl(entity.id)} 
-                target="_blank" 
-                rel="noopener noreferrer"
-                style={{ 
-                  display: 'inline-flex',
-                  alignItems: 'center',
-                  gap: '6px',
-                  padding: '8px 16px',
-                  backgroundColor: '#24292e',
-                  color: '#ffffff',
-                  textDecoration: 'none',
-                  borderRadius: '6px',
-                  fontSize: '0.9em',
-                  fontWeight: '500',
-                  transition: 'background-color 0.2s ease',
-                  border: 'none',
-                  cursor: 'pointer'
-                }}
-                onMouseEnter={(e) => e.currentTarget.style.backgroundColor = '#1a1e22'}
-                onMouseLeave={(e) => e.currentTarget.style.backgroundColor = '#24292e'}
-              >
-                <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-                  <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
-                </svg>
-                View JSON on GitHub
-                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                  <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
-                  <polyline points="15 3 21 3 21 9"></polyline>
-                  <line x1="10" y1="14" x2="21" y2="3"></line>
-                </svg>
-              </a>
+              <GitHubSourceLink entityId={entity.id} />
             </DetailField>
           </CollapsibleSection>
         </tbody>

--- a/src/components/entity_details/InternationalOrgDetails.tsx
+++ b/src/components/entity_details/InternationalOrgDetails.tsx
@@ -10,6 +10,7 @@ import AttributesDisplay from './AttributesDisplay';
 import TagsDisplay from './TagsDisplay';
 import CollapsibleSection from './CollapsibleSection';
 import { formattedDate } from '../../utils/date';
+import { getEntityGitHubUrl } from '../../utils/github';
 
 interface InternationalOrgDetailsProps {
   entity: Organization;
@@ -128,6 +129,40 @@ const InternationalOrgDetails: React.FC<InternationalOrgDetailsProps> = ({ entit
             <DetailField label="Change Description" labelNe="परिवर्तन विवरण">{entity.version_summary.change_description}</DetailField>
             <DetailField label="Last Modified" labelNe="अन्तिम परिमार्जन">{formattedDate(new Date(entity.version_summary.created_at))}</DetailField>
             <DetailField label="Created At" labelNe="सिर्जना मिति">{formattedDate(new Date(entity.created_at))}</DetailField>
+            <DetailField label="Source Data" labelNe="स्रोत डाटा">
+              <a 
+                href={getEntityGitHubUrl(entity.id)} 
+                target="_blank" 
+                rel="noopener noreferrer"
+                style={{ 
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: '6px',
+                  padding: '8px 16px',
+                  backgroundColor: '#24292e',
+                  color: '#ffffff',
+                  textDecoration: 'none',
+                  borderRadius: '6px',
+                  fontSize: '0.9em',
+                  fontWeight: '500',
+                  transition: 'background-color 0.2s ease',
+                  border: 'none',
+                  cursor: 'pointer'
+                }}
+                onMouseEnter={(e) => e.currentTarget.style.backgroundColor = '#1a1e22'}
+                onMouseLeave={(e) => e.currentTarget.style.backgroundColor = '#24292e'}
+              >
+                <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                  <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
+                </svg>
+                View JSON on GitHub
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
+                  <polyline points="15 3 21 3 21 9"></polyline>
+                  <line x1="10" y1="14" x2="21" y2="3"></line>
+                </svg>
+              </a>
+            </DetailField>
           </CollapsibleSection>
         </tbody>
       </table>

--- a/src/components/entity_details/LocationDetails.tsx
+++ b/src/components/entity_details/LocationDetails.tsx
@@ -11,6 +11,7 @@ import AttributesDisplay from './AttributesDisplay';
 import TagsDisplay from './TagsDisplay';
 import CollapsibleSection from './CollapsibleSection';
 import { formattedDate } from '../../utils/date';
+import { getEntityGitHubUrl } from '../../utils/github';
 
 interface LocationDetailsProps {
   entity: Location;
@@ -133,6 +134,40 @@ const LocationDetails: React.FC<LocationDetailsProps> = ({ entity }) => {
             <DetailField label="Change Description" labelNe="परिवर्तन विवरण">{entity.version_summary.change_description}</DetailField>
             <DetailField label="Last Modified" labelNe="अन्तिम परिमार्जन">{formattedDate(new Date(entity.version_summary.created_at))}</DetailField>
             <DetailField label="Created At" labelNe="सिर्जना मिति">{formattedDate(new Date(entity.created_at))}</DetailField>
+            <DetailField label="Source Data" labelNe="स्रोत डाटा">
+              <a 
+                href={getEntityGitHubUrl(entity.id)} 
+                target="_blank" 
+                rel="noopener noreferrer"
+                style={{ 
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: '6px',
+                  padding: '8px 16px',
+                  backgroundColor: '#24292e',
+                  color: '#ffffff',
+                  textDecoration: 'none',
+                  borderRadius: '6px',
+                  fontSize: '0.9em',
+                  fontWeight: '500',
+                  transition: 'background-color 0.2s ease',
+                  border: 'none',
+                  cursor: 'pointer'
+                }}
+                onMouseEnter={(e) => e.currentTarget.style.backgroundColor = '#1a1e22'}
+                onMouseLeave={(e) => e.currentTarget.style.backgroundColor = '#24292e'}
+              >
+                <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                  <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
+                </svg>
+                View JSON on GitHub
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
+                  <polyline points="15 3 21 3 21 9"></polyline>
+                  <line x1="10" y1="14" x2="21" y2="3"></line>
+                </svg>
+              </a>
+            </DetailField>
           </CollapsibleSection>
         </tbody>
       </table>

--- a/src/components/entity_details/LocationDetails.tsx
+++ b/src/components/entity_details/LocationDetails.tsx
@@ -10,8 +10,8 @@ import EntityLink from './EntityLink';
 import AttributesDisplay from './AttributesDisplay';
 import TagsDisplay from './TagsDisplay';
 import CollapsibleSection from './CollapsibleSection';
+import GitHubSourceLink from './GitHubSourceLink';
 import { formattedDate } from '../../utils/date';
-import { getEntityGitHubUrl } from '../../utils/github';
 
 interface LocationDetailsProps {
   entity: Location;
@@ -135,38 +135,7 @@ const LocationDetails: React.FC<LocationDetailsProps> = ({ entity }) => {
             <DetailField label="Last Modified" labelNe="अन्तिम परिमार्जन">{formattedDate(new Date(entity.version_summary.created_at))}</DetailField>
             <DetailField label="Created At" labelNe="सिर्जना मिति">{formattedDate(new Date(entity.created_at))}</DetailField>
             <DetailField label="Source Data" labelNe="स्रोत डाटा">
-              <a 
-                href={getEntityGitHubUrl(entity.id)} 
-                target="_blank" 
-                rel="noopener noreferrer"
-                style={{ 
-                  display: 'inline-flex',
-                  alignItems: 'center',
-                  gap: '6px',
-                  padding: '8px 16px',
-                  backgroundColor: '#24292e',
-                  color: '#ffffff',
-                  textDecoration: 'none',
-                  borderRadius: '6px',
-                  fontSize: '0.9em',
-                  fontWeight: '500',
-                  transition: 'background-color 0.2s ease',
-                  border: 'none',
-                  cursor: 'pointer'
-                }}
-                onMouseEnter={(e) => e.currentTarget.style.backgroundColor = '#1a1e22'}
-                onMouseLeave={(e) => e.currentTarget.style.backgroundColor = '#24292e'}
-              >
-                <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-                  <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
-                </svg>
-                View JSON on GitHub
-                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                  <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
-                  <polyline points="15 3 21 3 21 9"></polyline>
-                  <line x1="10" y1="14" x2="21" y2="3"></line>
-                </svg>
-              </a>
+              <GitHubSourceLink entityId={entity.id} />
             </DetailField>
           </CollapsibleSection>
         </tbody>

--- a/src/components/entity_details/NGODetails.tsx
+++ b/src/components/entity_details/NGODetails.tsx
@@ -9,8 +9,8 @@ import SectionHeader from './SectionHeader';
 import AttributesDisplay from './AttributesDisplay';
 import TagsDisplay from './TagsDisplay';
 import CollapsibleSection from './CollapsibleSection';
+import GitHubSourceLink from './GitHubSourceLink';
 import { formattedDate } from '../../utils/date';
-import { getEntityGitHubUrl } from '../../utils/github';
 
 interface NGODetailsProps {
   entity: Organization;
@@ -130,38 +130,7 @@ const NGODetails: React.FC<NGODetailsProps> = ({ entity }) => {
             <DetailField label="Last Modified" labelNe="अन्तिम परिमार्जन">{formattedDate(new Date(entity.version_summary.created_at))}</DetailField>
             <DetailField label="Created At" labelNe="सिर्जना मिति">{formattedDate(new Date(entity.created_at))}</DetailField>
             <DetailField label="Source Data" labelNe="स्रोत डाटा">
-              <a 
-                href={getEntityGitHubUrl(entity.id)} 
-                target="_blank" 
-                rel="noopener noreferrer"
-                style={{ 
-                  display: 'inline-flex',
-                  alignItems: 'center',
-                  gap: '6px',
-                  padding: '8px 16px',
-                  backgroundColor: '#24292e',
-                  color: '#ffffff',
-                  textDecoration: 'none',
-                  borderRadius: '6px',
-                  fontSize: '0.9em',
-                  fontWeight: '500',
-                  transition: 'background-color 0.2s ease',
-                  border: 'none',
-                  cursor: 'pointer'
-                }}
-                onMouseEnter={(e) => e.currentTarget.style.backgroundColor = '#1a1e22'}
-                onMouseLeave={(e) => e.currentTarget.style.backgroundColor = '#24292e'}
-              >
-                <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-                  <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
-                </svg>
-                View JSON on GitHub
-                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                  <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
-                  <polyline points="15 3 21 3 21 9"></polyline>
-                  <line x1="10" y1="14" x2="21" y2="3"></line>
-                </svg>
-              </a>
+              <GitHubSourceLink entityId={entity.id} />
             </DetailField>
           </CollapsibleSection>
         </tbody>

--- a/src/components/entity_details/NGODetails.tsx
+++ b/src/components/entity_details/NGODetails.tsx
@@ -10,6 +10,7 @@ import AttributesDisplay from './AttributesDisplay';
 import TagsDisplay from './TagsDisplay';
 import CollapsibleSection from './CollapsibleSection';
 import { formattedDate } from '../../utils/date';
+import { getEntityGitHubUrl } from '../../utils/github';
 
 interface NGODetailsProps {
   entity: Organization;
@@ -128,6 +129,40 @@ const NGODetails: React.FC<NGODetailsProps> = ({ entity }) => {
             <DetailField label="Change Description" labelNe="परिवर्तन विवरण">{entity.version_summary.change_description}</DetailField>
             <DetailField label="Last Modified" labelNe="अन्तिम परिमार्जन">{formattedDate(new Date(entity.version_summary.created_at))}</DetailField>
             <DetailField label="Created At" labelNe="सिर्जना मिति">{formattedDate(new Date(entity.created_at))}</DetailField>
+            <DetailField label="Source Data" labelNe="स्रोत डाटा">
+              <a 
+                href={getEntityGitHubUrl(entity.id)} 
+                target="_blank" 
+                rel="noopener noreferrer"
+                style={{ 
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: '6px',
+                  padding: '8px 16px',
+                  backgroundColor: '#24292e',
+                  color: '#ffffff',
+                  textDecoration: 'none',
+                  borderRadius: '6px',
+                  fontSize: '0.9em',
+                  fontWeight: '500',
+                  transition: 'background-color 0.2s ease',
+                  border: 'none',
+                  cursor: 'pointer'
+                }}
+                onMouseEnter={(e) => e.currentTarget.style.backgroundColor = '#1a1e22'}
+                onMouseLeave={(e) => e.currentTarget.style.backgroundColor = '#24292e'}
+              >
+                <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                  <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
+                </svg>
+                View JSON on GitHub
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
+                  <polyline points="15 3 21 3 21 9"></polyline>
+                  <line x1="10" y1="14" x2="21" y2="3"></line>
+                </svg>
+              </a>
+            </DetailField>
           </CollapsibleSection>
         </tbody>
       </table>

--- a/src/components/entity_details/OrganizationDetails.tsx
+++ b/src/components/entity_details/OrganizationDetails.tsx
@@ -9,8 +9,8 @@ import SectionHeader from './SectionHeader';
 import AttributesDisplay from './AttributesDisplay';
 import TagsDisplay from './TagsDisplay';
 import CollapsibleSection from './CollapsibleSection';
+import GitHubSourceLink from './GitHubSourceLink';
 import { formattedDate } from '../../utils/date';
-import { getEntityGitHubUrl } from '../../utils/github';
 
 interface OrganizationDetailsProps {
   entity: Organization | PoliticalParty;
@@ -110,38 +110,7 @@ const OrganizationDetails: React.FC<OrganizationDetailsProps> = ({ entity }) => 
             <DetailField label="Last Modified" labelNe="अन्तिम परिमार्जन">{formattedDate(new Date(entity.version_summary.created_at))}</DetailField>
             <DetailField label="Created At" labelNe="सिर्जना मिति">{formattedDate(new Date(entity.created_at))}</DetailField>
             <DetailField label="Source Data" labelNe="स्रोत डाटा">
-              <a 
-                href={getEntityGitHubUrl(entity.id)} 
-                target="_blank" 
-                rel="noopener noreferrer"
-                style={{ 
-                  display: 'inline-flex',
-                  alignItems: 'center',
-                  gap: '6px',
-                  padding: '8px 16px',
-                  backgroundColor: '#24292e',
-                  color: '#ffffff',
-                  textDecoration: 'none',
-                  borderRadius: '6px',
-                  fontSize: '0.9em',
-                  fontWeight: '500',
-                  transition: 'background-color 0.2s ease',
-                  border: 'none',
-                  cursor: 'pointer'
-                }}
-                onMouseEnter={(e) => e.currentTarget.style.backgroundColor = '#1a1e22'}
-                onMouseLeave={(e) => e.currentTarget.style.backgroundColor = '#24292e'}
-              >
-                <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-                  <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
-                </svg>
-                View JSON on GitHub
-                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                  <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
-                  <polyline points="15 3 21 3 21 9"></polyline>
-                  <line x1="10" y1="14" x2="21" y2="3"></line>
-                </svg>
-              </a>
+              <GitHubSourceLink entityId={entity.id} />
             </DetailField>
           </CollapsibleSection>
         </tbody>

--- a/src/components/entity_details/OrganizationDetails.tsx
+++ b/src/components/entity_details/OrganizationDetails.tsx
@@ -10,6 +10,7 @@ import AttributesDisplay from './AttributesDisplay';
 import TagsDisplay from './TagsDisplay';
 import CollapsibleSection from './CollapsibleSection';
 import { formattedDate } from '../../utils/date';
+import { getEntityGitHubUrl } from '../../utils/github';
 
 interface OrganizationDetailsProps {
   entity: Organization | PoliticalParty;
@@ -108,6 +109,40 @@ const OrganizationDetails: React.FC<OrganizationDetailsProps> = ({ entity }) => 
             <DetailField label="Change Description" labelNe="परिवर्तन विवरण">{entity.version_summary.change_description}</DetailField>
             <DetailField label="Last Modified" labelNe="अन्तिम परिमार्जन">{formattedDate(new Date(entity.version_summary.created_at))}</DetailField>
             <DetailField label="Created At" labelNe="सिर्जना मिति">{formattedDate(new Date(entity.created_at))}</DetailField>
+            <DetailField label="Source Data" labelNe="स्रोत डाटा">
+              <a 
+                href={getEntityGitHubUrl(entity.id)} 
+                target="_blank" 
+                rel="noopener noreferrer"
+                style={{ 
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: '6px',
+                  padding: '8px 16px',
+                  backgroundColor: '#24292e',
+                  color: '#ffffff',
+                  textDecoration: 'none',
+                  borderRadius: '6px',
+                  fontSize: '0.9em',
+                  fontWeight: '500',
+                  transition: 'background-color 0.2s ease',
+                  border: 'none',
+                  cursor: 'pointer'
+                }}
+                onMouseEnter={(e) => e.currentTarget.style.backgroundColor = '#1a1e22'}
+                onMouseLeave={(e) => e.currentTarget.style.backgroundColor = '#24292e'}
+              >
+                <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                  <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
+                </svg>
+                View JSON on GitHub
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
+                  <polyline points="15 3 21 3 21 9"></polyline>
+                  <line x1="10" y1="14" x2="21" y2="3"></line>
+                </svg>
+              </a>
+            </DetailField>
           </CollapsibleSection>
         </tbody>
       </table>

--- a/src/components/entity_details/PersonDetails.tsx
+++ b/src/components/entity_details/PersonDetails.tsx
@@ -10,11 +10,11 @@ import EntityLink from './EntityLink';
 import AttributesDisplay from './AttributesDisplay';
 import TagsDisplay from './TagsDisplay';
 import CollapsibleSection from './CollapsibleSection';
+import GitHubSourceLink from './GitHubSourceLink';
 
 import EducationSection from './EducationSection';
 import OccupationalHistorySection from './OccupationalHistorySection';
 import { formattedDate } from '../../utils/date';
-import { getEntityGitHubUrl } from '../../utils/github';
 
 interface PersonDetailsProps {
   entity: Person;
@@ -354,38 +354,7 @@ const PersonDetails: React.FC<PersonDetailsProps> = ({ entity }) => {
               <DetailField label="Last Modified" labelNe="अन्तिम परिमार्जन">{formattedDate(new Date(entity.version_summary.created_at))}</DetailField>
               <DetailField label="Created At" labelNe="सिर्जना मिति">{formattedDate(new Date(entity.created_at))}</DetailField>
               <DetailField label="Source Data" labelNe="स्रोत डाटा">
-                <a 
-                  href={getEntityGitHubUrl(entity.id)} 
-                  target="_blank" 
-                  rel="noopener noreferrer"
-                  style={{ 
-                    display: 'inline-flex',
-                    alignItems: 'center',
-                    gap: '6px',
-                    padding: '8px 16px',
-                    backgroundColor: '#24292e',
-                    color: '#ffffff',
-                    textDecoration: 'none',
-                    borderRadius: '6px',
-                    fontSize: '0.9em',
-                    fontWeight: '500',
-                    transition: 'background-color 0.2s ease',
-                    border: 'none',
-                    cursor: 'pointer'
-                  }}
-                  onMouseEnter={(e) => e.currentTarget.style.backgroundColor = '#1a1e22'}
-                  onMouseLeave={(e) => e.currentTarget.style.backgroundColor = '#24292e'}
-                >
-                  <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-                    <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
-                  </svg>
-                  View JSON on GitHub
-                  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                    <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
-                    <polyline points="15 3 21 3 21 9"></polyline>
-                    <line x1="10" y1="14" x2="21" y2="3"></line>
-                  </svg>
-                </a>
+                <GitHubSourceLink entityId={entity.id} />
               </DetailField>
             </CollapsibleSection>
           </tbody>

--- a/src/components/entity_details/PersonDetails.tsx
+++ b/src/components/entity_details/PersonDetails.tsx
@@ -14,6 +14,7 @@ import CollapsibleSection from './CollapsibleSection';
 import EducationSection from './EducationSection';
 import OccupationalHistorySection from './OccupationalHistorySection';
 import { formattedDate } from '../../utils/date';
+import { getEntityGitHubUrl } from '../../utils/github';
 
 interface PersonDetailsProps {
   entity: Person;
@@ -352,6 +353,40 @@ const PersonDetails: React.FC<PersonDetailsProps> = ({ entity }) => {
               <DetailField label="Change Description" labelNe="परिवर्तन विवरण">{entity.version_summary.change_description}</DetailField>
               <DetailField label="Last Modified" labelNe="अन्तिम परिमार्जन">{formattedDate(new Date(entity.version_summary.created_at))}</DetailField>
               <DetailField label="Created At" labelNe="सिर्जना मिति">{formattedDate(new Date(entity.created_at))}</DetailField>
+              <DetailField label="Source Data" labelNe="स्रोत डाटा">
+                <a 
+                  href={getEntityGitHubUrl(entity.id)} 
+                  target="_blank" 
+                  rel="noopener noreferrer"
+                  style={{ 
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: '6px',
+                    padding: '8px 16px',
+                    backgroundColor: '#24292e',
+                    color: '#ffffff',
+                    textDecoration: 'none',
+                    borderRadius: '6px',
+                    fontSize: '0.9em',
+                    fontWeight: '500',
+                    transition: 'background-color 0.2s ease',
+                    border: 'none',
+                    cursor: 'pointer'
+                  }}
+                  onMouseEnter={(e) => e.currentTarget.style.backgroundColor = '#1a1e22'}
+                  onMouseLeave={(e) => e.currentTarget.style.backgroundColor = '#24292e'}
+                >
+                  <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                    <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
+                  </svg>
+                  View JSON on GitHub
+                  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
+                    <polyline points="15 3 21 3 21 9"></polyline>
+                    <line x1="10" y1="14" x2="21" y2="3"></line>
+                  </svg>
+                </a>
+              </DetailField>
             </CollapsibleSection>
           </tbody>
         </table>

--- a/src/components/entity_details/ProjectDetails.tsx
+++ b/src/components/entity_details/ProjectDetails.tsx
@@ -5,6 +5,7 @@ import SectionHeader from './SectionHeader';
 import AttributesDisplay from './AttributesDisplay';
 import CollapsibleSection from './CollapsibleSection';
 import { formattedDate } from '../../utils/date';
+import { getEntityGitHubUrl } from '../../utils/github';
 
 interface ProjectDetailsProps {
   entity: Project;
@@ -173,6 +174,40 @@ const ProjectDetails: React.FC<ProjectDetailsProps> = ({ entity }) => {
             <DetailField label="Change Description" labelNe="परिवर्तन विवरण">{entity.version_summary.change_description}</DetailField>
             <DetailField label="Last Modified" labelNe="अन्तिम परिमार्जन">{formattedDate(new Date(entity.version_summary.created_at))}</DetailField>
             <DetailField label="Created At" labelNe="सिर्जना मिति">{formattedDate(new Date(entity.created_at))}</DetailField>
+            <DetailField label="Source Data" labelNe="स्रोत डाटा">
+              <a 
+                href={getEntityGitHubUrl(entity.id)} 
+                target="_blank" 
+                rel="noopener noreferrer"
+                style={{ 
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: '6px',
+                  padding: '8px 16px',
+                  backgroundColor: '#24292e',
+                  color: '#ffffff',
+                  textDecoration: 'none',
+                  borderRadius: '6px',
+                  fontSize: '0.9em',
+                  fontWeight: '500',
+                  transition: 'background-color 0.2s ease',
+                  border: 'none',
+                  cursor: 'pointer'
+                }}
+                onMouseEnter={(e) => e.currentTarget.style.backgroundColor = '#1a1e22'}
+                onMouseLeave={(e) => e.currentTarget.style.backgroundColor = '#24292e'}
+              >
+                <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                  <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
+                </svg>
+                View JSON on GitHub
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
+                  <polyline points="15 3 21 3 21 9"></polyline>
+                  <line x1="10" y1="14" x2="21" y2="3"></line>
+                </svg>
+              </a>
+            </DetailField>
           </CollapsibleSection>
         </tbody>
       </table>

--- a/src/components/entity_details/ProjectDetails.tsx
+++ b/src/components/entity_details/ProjectDetails.tsx
@@ -4,8 +4,8 @@ import DetailField from './DetailField';
 import SectionHeader from './SectionHeader';
 import AttributesDisplay from './AttributesDisplay';
 import CollapsibleSection from './CollapsibleSection';
+import GitHubSourceLink from './GitHubSourceLink';
 import { formattedDate } from '../../utils/date';
-import { getEntityGitHubUrl } from '../../utils/github';
 
 interface ProjectDetailsProps {
   entity: Project;
@@ -175,38 +175,7 @@ const ProjectDetails: React.FC<ProjectDetailsProps> = ({ entity }) => {
             <DetailField label="Last Modified" labelNe="अन्तिम परिमार्जन">{formattedDate(new Date(entity.version_summary.created_at))}</DetailField>
             <DetailField label="Created At" labelNe="सिर्जना मिति">{formattedDate(new Date(entity.created_at))}</DetailField>
             <DetailField label="Source Data" labelNe="स्रोत डाटा">
-              <a 
-                href={getEntityGitHubUrl(entity.id)} 
-                target="_blank" 
-                rel="noopener noreferrer"
-                style={{ 
-                  display: 'inline-flex',
-                  alignItems: 'center',
-                  gap: '6px',
-                  padding: '8px 16px',
-                  backgroundColor: '#24292e',
-                  color: '#ffffff',
-                  textDecoration: 'none',
-                  borderRadius: '6px',
-                  fontSize: '0.9em',
-                  fontWeight: '500',
-                  transition: 'background-color 0.2s ease',
-                  border: 'none',
-                  cursor: 'pointer'
-                }}
-                onMouseEnter={(e) => e.currentTarget.style.backgroundColor = '#1a1e22'}
-                onMouseLeave={(e) => e.currentTarget.style.backgroundColor = '#24292e'}
-              >
-                <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-                  <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
-                </svg>
-                View JSON on GitHub
-                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                  <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
-                  <polyline points="15 3 21 3 21 9"></polyline>
-                  <line x1="10" y1="14" x2="21" y2="3"></line>
-                </svg>
-              </a>
+              <GitHubSourceLink entityId={entity.id} />
             </DetailField>
           </CollapsibleSection>
         </tbody>

--- a/src/components/entity_details/index.ts
+++ b/src/components/entity_details/index.ts
@@ -17,3 +17,4 @@ export { default as EntityLink } from './EntityLink';
 export { default as AttributesDisplay } from './AttributesDisplay';
 export { default as TagsDisplay } from './TagsDisplay';
 export { default as CollapsibleSection } from './CollapsibleSection';
+export { default as GitHubSourceLink } from './GitHubSourceLink';

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -1,0 +1,11 @@
+/**
+ * Generate GitHub URL for entity JSON file
+ * @param entityId - Full entity ID (e.g., "entity:person/pushpa-kamal-dahal-prachanda")
+ * @returns GitHub URL to the JSON file
+ */
+export function getEntityGitHubUrl(entityId: string): string {
+  // Remove "entity:" prefix if present
+  const path = entityId.replace(/^entity:/, '');
+  
+  return `https://github.com/NewNepal-org/NepalEntityService-database/blob/main/v2/entity/${path}.json`;
+}


### PR DESCRIPTION
## Summary
Adds a prominent "View JSON on GitHub" button to all entity detail pages, allowing users to easily access the source JSON data for any entity.

## Changes
- Created `getEntityGitHubUrl` utility function in `src/utils/github.ts` to generate GitHub URLs from entity IDs
- Added "Source Data / स्रोत डाटा" field in the "Version & Audit Details" section
- Implemented as a styled button with:
  - GitHub logo icon
  - Dark GitHub-style background (#24292e)
  - External link icon
  - Hover effect for better UX
- Applied to all entity detail components:
  - PersonDetails
  - OrganizationDetails
  - LocationDetails
  - ProjectDetails
  - NGODetails
  - InternationalOrgDetails

## Example
For entity: `entity:person/pushpa-kamal-dahal-prachanda`

The button links to: `https://github.com/NewNepal-org/NepalEntityService-database/blob/main/v2/entity/person/pushpa-kamal-dahal-prachanda.json`

## Benefits
- ✅ Easy access to raw entity data
- ✅ Transparency - users can see the source data
- ✅ Developers can quickly reference the JSON structure
- ✅ Prominent, visually distinct button for instant recognition

## Testing
- ✅ Build passes successfully
- ✅ TypeScript compilation with no errors
- Test locally: Navigate to any entity page and expand "View Version & Audit Details" section

<img width="1558" height="833" alt="image" src="https://github.com/user-attachments/assets/64d0562b-375a-4f89-82e9-e023bf99923e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Source Data" link in the entity details view for all entity types
  * Users can now view JSON-formatted entity data on GitHub directly from the application interface
  * Available for organizations, persons, projects, locations, and international organizations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->